### PR TITLE
Add `Deploy to Swifton.me` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Click the button below to automatically set up this example to run on your own H
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/kylef/Curassow-example-helloworld)
 
+or (in case you're feelin' experimental)
+
+[![Deploy to Swifton.me](https://serve.swifton.me/badge.png)](https://serve.swifton.me/oneclick?repository=https://github.com/SwiftOnMe/swifton-serve-example)
+
 ### Options
 
 ```shell


### PR DESCRIPTION
I've written and set up a Swift web app PaaS based on Docker and Node.js.
It's open source and you can find it here: https://github.com/SwiftOnMe

I thought you'd like to add this to the README so people can check it out using One-click deployment. Deploying Swift web apps will never be the same again... :wink: 
